### PR TITLE
Handle unset HTTP_USER_AGENT in Googlepay and Applepay

### DIFF
--- a/app/code/local/Radarsofthouse/Reepay/Model/Applepay.php
+++ b/app/code/local/Radarsofthouse/Reepay/Model/Applepay.php
@@ -47,7 +47,7 @@ class Radarsofthouse_Reepay_Model_Applepay extends Radarsofthouse_Reepay_Model_S
      * @return bollean
      */
     public function isAvailable($quote = null){
-        $user_agent = $_SERVER['HTTP_USER_AGENT'];
+        $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
         if(stripos( $user_agent, 'Edg') !== false){
             return false;
         }else if(stripos( $user_agent, 'Chrome') !== false){

--- a/app/code/local/Radarsofthouse/Reepay/Model/Googlepay.php
+++ b/app/code/local/Radarsofthouse/Reepay/Model/Googlepay.php
@@ -47,7 +47,7 @@ class Radarsofthouse_Reepay_Model_Googlepay extends Radarsofthouse_Reepay_Model_
      * @return bollean
      */
     public function isAvailable($quote = null){
-        $user_agent = $_SERVER['HTTP_USER_AGENT'];
+        $user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
         if(stripos( $user_agent, 'Edg') !== false){
             return false;
         }elseif (stripos( $user_agent, 'Chrome') !== false){


### PR DESCRIPTION
User Agent isn't always set - which dumps a notice